### PR TITLE
Use MutationObserver instead of deprecated DOMNodeInserted event

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -76,7 +76,7 @@ const observer = new MutationObserver((mutationsList) => {
   }
 });
 
-observer.observe(document.body, {
+observer.observe(document, {
   childList: true,
   subtree: true,
 });

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -55,19 +55,28 @@ const injectDOM = (userName) => {
   });
 };
 
-document.addEventListener(
-  "DOMNodeInserted",
-  function (e) {
-    e.target.content &&
-      e.target.content.includes("(@") &&
-      document.querySelector('[data-testid="UserName"]') &&
-      injectDOM(
-        Array.from(
-          document
-            .querySelector('[data-testid="UserName"]')
-            .querySelectorAll("span")
-        ).find((span) => span.textContent.startsWith("@")).textContent
-      );
-  },
-  false
-);
+const observer = new MutationObserver((mutationsList) => {
+  for (let mutation of mutationsList) {
+    if (mutation.type === 'childList') {
+      mutation.addedNodes.forEach((node) => {
+        if (
+          node.nodeType === Node.ELEMENT_NODE &&
+          node.textContent.includes("(@") &&
+          document.querySelector('[data-testid="UserName"]')
+        ) {
+          const userName = Array.from(
+            document
+              .querySelector('[data-testid="UserName"]')
+              .querySelectorAll("span")
+          ).find((span) => span.textContent.startsWith("@")).textContent;
+          injectDOM(userName);
+        }
+      });
+    }
+  }
+});
+
+observer.observe(document.body, {
+  childList: true,
+  subtree: true,
+});


### PR DESCRIPTION
I needed this fix due to https://chromestatus.com/feature/5083947249172480. Unfortunately, it isn't a perfect fix. There must be a race condition or some bug because the note area doesn't always appear on profiles. My pull request would replace good functionality on old browsers with flaky functionality on modern browsers, but I don't have time to fix it right now. So no worries if you don't want to merge it!